### PR TITLE
Refactor git scanner to async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/git-scanner/history.json
+# Ignore scan history
 history.json

--- a/README.MD
+++ b/README.MD
@@ -14,6 +14,7 @@ Git Scanner is a cross-platform Node.js command-line utility for scanning and ma
 - 🔄 Actions: `add`, `commit`, `push`, `restore`, `skip`
 - 🔁 Stays running until the user exits
 - ✅ Confirmation prompts for sensitive actions
+- ⚡ Asynchronous scanning for improved performance
 
 ---
 
@@ -48,10 +49,13 @@ node scanner.js
 ## ▶️ Usage
 
 ```bash
-git-scan
+git-scan [path] [--depth=N]
 ```
 
-1. Choose the folder you want to scan (defaults to current working directory).
+- **path** - directory to scan (defaults to the current working directory)
+- **--depth** - limit recursion depth (default: unlimited)
+
+1. Choose the folder you want to scan or provide it directly as the first argument.
 2. Git Scanner will recursively detect all Git repositories.
 3. It will group and display them by status:
    - 🟢 Clean

--- a/scanner.js
+++ b/scanner.js
@@ -1,74 +1,82 @@
 #!/usr/bin/env node
 
-const { execSync } = require("child_process");
-const { ask, rl, close } = require("./utils/ask.js");
-const { handleRepo } = require("./utils/repoActions");
-const findGitRepos = require("./utils/gitScanner");
-const { updateHistoryEntry, loadHistory } = require("./utils/historyHandler");
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const path = require('path');
+const { ask, rl, close } = require('./utils/ask.js');
+const { handleRepo } = require('./utils/repoActions');
+const findGitRepos = require('./utils/gitScanner');
+const { updateHistoryEntry, loadHistory } = require('./utils/historyHandler');
+
+const execAsync = promisify(exec);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let target = null;
+  let depth = Infinity;
+  for (const arg of args) {
+    if (arg.startsWith('--depth=')) {
+      depth = parseInt(arg.split('=')[1], 10);
+    } else if (!target) {
+      target = arg;
+    }
+  }
+  return { target, depth: isNaN(depth) ? Infinity : depth };
+}
 
 async function main() {
   console.clear();
-  // Show recent scan locations (history)
-  const history = loadHistory().slice(-3).reverse(); // last 3 runs, latest first
-  let baseDir;
-  if (history.length > 0) {
-    console.log("📜 Recent scan locations:");
+  const { target, depth } = parseArgs();
+  const history = loadHistory().slice(-3).reverse();
+
+  let baseDir = target;
+  if (!baseDir && history.length > 0) {
+    console.log('📜 Recent scan locations:');
     history.forEach((entry, index) => {
       console.log(`[${index + 1}] ${entry.path} (${entry.status})`);
     });
-    const histChoice = await ask(
-      "\n🔁 Choose a location to re-scan (1-3) or press Enter to choose manually: "
-    );
+    const histChoice = await ask('\n🔁 Choose a location to re-scan (1-3) or press Enter to choose manually: ');
     const histIndex = parseInt(histChoice.trim(), 10);
     if (histIndex >= 1 && histIndex <= history.length) {
       baseDir = history[histIndex - 1].path;
     }
   }
-  console.log("-------------------------");
-  console.log(" ");
+
   const defaultPath = process.cwd();
   if (!baseDir) {
-    const inputPath = await ask(
-      `📁 Enter folder to scan [default: current directory]: `
-    );
-    baseDir = inputPath.trim() === "" ? defaultPath : inputPath.trim();
+    const inputPath = await ask(`📁 Enter folder to scan [default: current directory]: `);
+    baseDir = inputPath.trim() === '' ? defaultPath : inputPath.trim();
   }
 
   while (true) {
     console.clear();
     console.log(`\n🔍 Scanning: ${baseDir}...\n`);
-    const repos = await findGitRepos(baseDir);
+    const repos = await findGitRepos(baseDir, depth);
 
     if (repos.length === 0) {
-      console.log("❌ No Git repositories found.");
+      console.log('❌ No Git repositories found.');
       break;
     }
 
     const reposWithStatus = [];
-    let baseDirStatus = "🟢";
+    let baseDirStatus = '🟢';
 
-    for (let i = 0; i < repos.length; i++) {
-      const repo = repos[i];
-      let statusSymbol = "🟢";
+    for (const repo of repos) {
+      let statusSymbol = '🟢';
       try {
-        const status = execSync("git status --porcelain", {
-          cwd: repo,
-          encoding: "utf8",
-          stdio: ["ignore", "pipe", "ignore"],
-        });
-        if (status.trim()) statusSymbol = "🟡";
+        const { stdout } = await execAsync('git status --porcelain', { cwd: repo });
+        if (stdout.trim()) statusSymbol = '🟡';
       } catch {
-        statusSymbol = "🔴";
+        statusSymbol = '🔴';
       }
 
-      if (repo === require("path").resolve(baseDir)) {
+      if (path.resolve(repo) === path.resolve(baseDir)) {
         baseDirStatus = statusSymbol;
       }
 
       reposWithStatus.push({ repo, statusSymbol });
     }
 
-    // Only update history once for baseDir itself
     updateHistoryEntry(
       {
         path: baseDir,
@@ -79,45 +87,38 @@ async function main() {
       baseDir
     );
 
-    // Sort repos: green (🟢) first, then yellow (🟡), then red (🔴)
     reposWithStatus.sort((a, b) => {
-      const order = { "🟢": 0, "🟡": 1, "🔴": 2 };
+      const order = { '🟢': 0, '🟡': 1, '🔴': 2 };
       return order[a.statusSymbol] - order[b.statusSymbol];
     });
 
-    for (let i = 0; i < reposWithStatus.length; i++) {
-      const { repo, statusSymbol } = reposWithStatus[i];
+    reposWithStatus.forEach(({ repo, statusSymbol }, i) => {
       console.log(`${statusSymbol} 📁 ${i + 1}. ${repo}`);
-    }
+    });
 
-    console.log("\nLegend:");
-    console.log("🟢 Clean repo");
-    console.log("🟡 Uncommitted changes");
-    console.log("🔴 Git error or inaccessible\n");
+    console.log('\nLegend:');
+    console.log('🟢 Clean repo');
+    console.log('🟡 Uncommitted changes');
+    console.log('🔴 Git error or inaccessible\n');
 
-    const choice = await ask(
-      "🔢 Enter number of repo to act on (or press Enter to exit): "
-    );
+    const choice = await ask('🔢 Enter number of repo to act on (or press Enter to exit): ');
     const index = parseInt(choice.trim(), 10) - 1;
 
     if (isNaN(index) || !reposWithStatus[index]) {
-      console.log("👋 Bye.");
+      console.log('👋 Bye.');
       close();
-      console.log("\n💡 You may now continue using the terminal.\n");
+      console.log('\n💡 You may now continue using the terminal.\n');
       break;
     }
 
     const selected = reposWithStatus[index].repo;
     console.log(`\n➡️ Selected: ${selected}\n`);
     try {
-      const result = execSync("git status", {
-        cwd: selected,
-        encoding: "utf8",
-      });
-      console.log("📄 Git status:\n");
-      console.log(result);
-    } catch (e) {
-      console.log("❌ Failed to run git status");
+      const { stdout } = await execAsync('git status', { cwd: selected });
+      console.log('📄 Git status:\n');
+      console.log(stdout);
+    } catch {
+      console.log('❌ Failed to run git status');
     }
 
     await handleRepo(selected);

--- a/utils/repoActions.js
+++ b/utils/repoActions.js
@@ -1,59 +1,57 @@
-const { execSync } = require("child_process");
-const { ask } = require("./ask");
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const { ask } = require('./ask');
+
+const execAsync = promisify(exec);
+
+async function runCommand(cmd, cwd) {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { cwd, shell: true });
+    if (stdout) process.stdout.write(stdout);
+    if (stderr) process.stderr.write(stderr);
+    return true;
+  } catch (e) {
+    if (e.stdout) process.stdout.write(e.stdout);
+    if (e.stderr) process.stderr.write(e.stderr);
+    return false;
+  }
+}
 
 async function handleRepo(repo) {
   console.log(`\nOptions for repo: ${repo}`);
-  console.log("Choose action:");
-  console.log("[1] Push changes (add + commit + push)");
-  console.log("[2] Add all changes (git add .)");
-  console.log("[3] Restore changes (git restore .)");
-  console.log("[4] Commit (only if already added)");
-  console.log("\x1b[31m[Enter] Cancel\x1b[0m"); // Red colored cancel
-  const action = await ask("> ");
+  console.log('Choose action:');
+  console.log('[1] Push changes (add + commit + push)');
+  console.log('[2] Add all changes (git add .)');
+  console.log('[3] Restore changes (git restore .)');
+  console.log('[4] Commit (only if already added)');
+  console.log('\x1b[31m[Enter] Cancel\x1b[0m');
+  const action = await ask('> ');
 
   switch (action.trim()) {
-    case "1":
-      const commitMsg = await ask("📝 Enter commit message: ");
-      try {
-        execSync(`git add . && git commit -m "${commitMsg}" && git push`, {
-          cwd: repo,
-          stdio: "inherit",
-        });
-        console.log("✅ Changes pushed successfully.");
-      } catch (e) {
-        console.log("❌ Failed to push changes.");
-      }
+    case '1': {
+      const commitMsg = await ask('📝 Enter commit message: ');
+      const ok = await runCommand(`git add . && git commit -m "${commitMsg}" && git push`, repo);
+      console.log(ok ? '✅ Changes pushed successfully.' : '❌ Failed to push changes.');
       break;
-    case "2":
-      try {
-        execSync(`git add .`, { cwd: repo, stdio: "inherit" });
-        console.log("✅ Changes added.");
-      } catch (e) {
-        console.log("❌ Failed to add changes.");
-      }
+    }
+    case '2': {
+      const ok = await runCommand('git add .', repo);
+      console.log(ok ? '✅ Changes added.' : '❌ Failed to add changes.');
       break;
-    case "3":
-      try {
-        execSync(`git restore .`, { cwd: repo, stdio: "inherit" });
-        console.log("🔄 Changes restored.");
-      } catch (e) {
-        console.log("❌ Failed to restore.");
-      }
+    }
+    case '3': {
+      const ok = await runCommand('git restore .', repo);
+      console.log(ok ? '🔄 Changes restored.' : '❌ Failed to restore.');
       break;
-    case "4":
-      const msg = await ask("📝 Enter commit message: ");
-      try {
-        execSync(`git commit -m "${msg}"`, {
-          cwd: repo,
-          stdio: "inherit",
-        });
-        console.log("✅ Committed.");
-      } catch (e) {
-        console.log("❌ Commit failed.");
-      }
+    }
+    case '4': {
+      const msg = await ask('📝 Enter commit message: ');
+      const ok = await runCommand(`git commit -m "${msg}"`, repo);
+      console.log(ok ? '✅ Committed.' : '❌ Commit failed.');
       break;
+    }
     default:
-      console.log("❌ Cancelled.");
+      console.log('❌ Cancelled.');
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor repository scanning and repo actions to use asynchronous APIs
- add simple CLI arguments for path and depth
- clean `.gitignore`
- document async feature and new CLI options

## Testing
- `node scanner.js --depth=1` *(fails: readline closed)*

------
https://chatgpt.com/codex/tasks/task_e_6887653720a88325b8c00d0ac651dd0b